### PR TITLE
Implement socket timeouts

### DIFF
--- a/lib/kjess/client.rb
+++ b/lib/kjess/client.rb
@@ -95,7 +95,13 @@ module KJess
       opts = opts.merge( :queue_name => queue_name )
       g    = KJess::Request::Get.new( opts )
 
-      connection.with_additional_read_timeout(opts[:wait_for] || 0.1) do
+      if opts[:wait_for]
+        wait_for_in_seconds = opts[:wait_for] / 1000
+      else
+        wait_for_in_seconds = 0.1
+      end
+
+      connection.with_additional_read_timeout(wait_for_in_seconds) do
         resp = send_recv( g )
         return resp.data if KJess::Response::Value === resp
         return nil

--- a/lib/kjess/client.rb
+++ b/lib/kjess/client.rb
@@ -94,7 +94,11 @@ module KJess
     def get( queue_name, opts = {} )
       opts = opts.merge( :queue_name => queue_name )
       g    = KJess::Request::Get.new( opts )
-      resp = send_recv( g )
+      resp = nil
+
+      connection.with_read_timeout(opts[:wait_for]) do
+        resp = send_recv( g )
+      end
 
       return resp.data if KJess::Response::Value === resp
       return nil

--- a/lib/kjess/connection.rb
+++ b/lib/kjess/connection.rb
@@ -45,8 +45,6 @@ module KJess
 
       @socket         = nil
       @read_buffer    = ''
-      @read_deadline  = nil
-      @write_deadline = nil
     end
 
     # Internal: Adds time to the read timeout

--- a/lib/kjess/connection.rb
+++ b/lib/kjess/connection.rb
@@ -183,7 +183,7 @@ module KJess
           @read_buffer << readpartial(10240)
         end
 
-        line = @read_buffer.slice!(0, idx + eom.bytesize)
+        line = @read_buffer.slice!(0, idx + eom.length)
         $stderr.puts "<-- #{line}" if $DEBUG
         break unless line.strip.length == 0
       end
@@ -203,8 +203,8 @@ module KJess
     #
     # Returns what IO#read returns
     def read( nbytes )
-      while @read_buffer.bytesize < nbytes
-        @read_buffer << readpartial(nbytes - @read_buffer.bytesize)
+      while @read_buffer.length < nbytes
+        @read_buffer << readpartial(nbytes - @read_buffer.length)
       end
 
       result = @read_buffer.slice!(0, nbytes)

--- a/lib/kjess/connection.rb
+++ b/lib/kjess/connection.rb
@@ -8,6 +8,7 @@ module KJess
   # Connection
   class Connection
     class Error < KJess::Error; end
+    class Timeout < Error; end
 
     CRLF = "\r\n"
 
@@ -19,10 +20,22 @@ module KJess
     # The port number to connect to. Default 22133
     attr_reader :port
 
-    def initialize( host, port = 22133 )
-      @host   = host
-      @port   = Float( port ).to_i
-      @socket = nil
+    def initialize( host, port = 22133, options = {} )
+      if port.is_a?(Hash)
+        options = port
+        port = 22133
+      end
+
+      @host            = host
+      @port            = Float( port ).to_i
+
+      @connect_timeout = options[:connect_timeout] || 2
+      @read_timeout    = options[:read_timeout]    || 2
+      @write_timeout   = options[:write_timeout]   || 2
+      @eol             = options[:eol]             || Protocol::CRLF
+
+      @read_buffer = ''
+      @socket      = nil
     end
 
     # Internal: Return the raw socket that is connected to the Kestrel server
@@ -40,26 +53,57 @@ module KJess
     #
     # Returns a TCPSocket
     def connect
-      sock = TCPSocket.new( host, port )
+      exception = nil
 
-      # close file descriptors if we exec or something like that
-      sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+      # Calculate our timeout deadline
+      deadline = Time.now.to_f + @connect_timeout
 
-      # Disable Nagle's algorithm
-      sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+      # Lookup address
+      addrs = ::Socket.getaddrinfo(host, nil)
 
-      # limit only to IPv4?
-      # addr = ::Socket.getaddrinfo(host, nil, Socket::AF_INET)
-      # sock = ::Socket.new(::Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0)
-      # saddr = ::Socket.pack_sockaddr_in(port, addr[0][3])
+      addrs.each do |addr|
+        timeout = deadline - Time.now.to_f
+        if timeout <= 0
+          raise Timeout, "Could not connect to #{host}:#{port}"
+        end
 
-      # tcp keepalive
-      # :SOL_SOCKET, :SO_KEEPALIVE, :SOL_TCP, :TCP_KEEPIDLE, :TCP_KEEPINTVL, :TCP_KEEPCNT].all?{|c| Socket.const_defined? c}
-      # @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE,  true)
-      # @sock.setsockopt(Socket::SOL_TCP,    Socket::TCP_KEEPIDLE,  keepalive[:time])
-      # @sock.setsockopt(Socket::SOL_TCP,    Socket::TCP_KEEPINTVL, keepalive[:intvl])
-      # @sock.setsockopt(Socket::SOL_TCP,    Socket::TCP_KEEPCNT,   keepalive[:probes])
-      return sock
+        begin
+          sock     = ::Socket.new(addr[4], Socket::SOCK_STREAM, 0)
+          sockaddr = ::Socket.pack_sockaddr_in(port, addr[3])
+
+          # close file descriptors if we exec
+          sock.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+
+          # Disable Nagle's algorithm
+          sock.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+
+          begin
+            sock.connect_nonblock(sockaddr)
+          rescue Errno::EINPROGRESS
+            if IO.select(nil, [sock], nil, timeout) == nil
+              raise Timeout, "Could not connect to #{host}:#{port}"
+            end
+
+            begin
+              sock.connect_nonblock(sockaddr)
+            rescue Errno::EISCONN
+            rescue => ex
+              exception = ex
+              next
+            end
+          rescue => ex
+            exception = ex
+            next
+          end
+
+          return sock
+        rescue
+          sock.close
+          raise
+        end
+      end
+
+      raise Error, "Could not connect to #{host}:#{port}: #{exception.class}: #{exception.message}", exception.backtrace
     end
 
     # Internal: close the socket if it is not already closed
@@ -94,12 +138,27 @@ module KJess
     # eom - the End Of Mesasge delimiter (default: "\r\n")
     #
     # Returns a String
-    def readline( eom = Protocol::CRLF )
-      while line = socket.readline( eom ) do
+    def readline( read_timeout = nil )
+      read_timeout ||= @read_timeout
+
+      deadline = Time.now.to_f + read_timeout
+
+      begin
+        while (idx = @read_buffer.index(@eol)) == nil
+          timeout = deadline - Time.now.to_f
+          if timeout <= 0
+            @read_buffer = result + @read_buffer
+            raise Timeout, "Could not read from #{host}:#{port}"
+          end
+
+          @read_buffer << readpartial(4096, timeout)
+        end
+
+        line = @read_buffer.slice!(0, idx + @eol.bytesize)
         $stderr.write "<-- #{line}" if $DEBUG
-        break unless line.strip.length == 0
+        retry if line.strip.length == 0
+        return line
       end
-      return line
     rescue EOFError
       close
       return "EOF"
@@ -110,10 +169,39 @@ module KJess
     # args - this method takes the same arguments as IO#read
     #
     # Returns what IO#read returns
-    def read( *args )
-      d = socket.read( *args )
-      $stderr.puts "<-- #{d}" if $DEBUG
-      return d
+    def read( nbytes, read_timeout = nil )
+      read_timeout ||= @read_timeout
+
+      deadline = Time.now.to_f + read_timeout
+
+      result = @read_buffer.slice!(0, nbytes)
+
+      while result.bytesize < nbytes
+        timeout = deadline - Time.now.to_f
+        if timeout <= 0
+          @read_buffer = result + @read_buffer
+          raise Timeout, "Could not read from #{host}:#{port}"
+        end
+
+        result << readpartial(nbytes - result.bytesize, timeout)
+      end
+
+      $stderr.puts "<-- #{result}" if $DEBUG
+      return result
+    end
+
+    def readpartial(maxlen, timeout = nil )
+      timeout ||= @read_timeout
+
+      begin
+        socket.read_nonblock(maxlen)
+      rescue Errno::EWOULDBLOCK, Errno::EAGAIN
+        if IO.select([socket], nil, nil, timeout)
+          retry
+        else
+          raise Timeout, "Could not read from #{host}:#{port} in #{timeout} seconds"
+        end
+      end
     end
   end
 end

--- a/lib/kjess/connection.rb
+++ b/lib/kjess/connection.rb
@@ -157,7 +157,7 @@ module KJess
 
       begin
         until msg.length == 0
-          written = socket.syswrite(msg)
+          written = socket.write_nonblock(msg)
           msg = msg[written, msg.length]
         end
       rescue Errno::EWOULDBLOCK, Errno::EINTR, Errno::EAGAIN
@@ -217,7 +217,7 @@ module KJess
     end
 
     def readpartial(maxlen, outbuf = nil)
-      return socket.sysread(maxlen, outbuf)
+      return socket.read_nonblock(maxlen, outbuf)
     rescue Errno::EWOULDBLOCK, Errno::EAGAIN
       if IO.select([socket], nil, nil, @read_timeout)
         retry

--- a/lib/kjess/connection.rb
+++ b/lib/kjess/connection.rb
@@ -10,8 +10,6 @@ module KJess
     class Error < KJess::Error; end
     class Timeout < Error; end
 
-    CRLF = "\r\n"
-
     # Public:
     # The hostname/ip address to connect to
     attr_reader :host
@@ -19,6 +17,18 @@ module KJess
     # Public
     # The port number to connect to. Default 22133
     attr_reader :port
+
+    # Public
+    # The timeout for connecting in seconds. Defaults to 2
+    attr_accessor :connect_timeout
+
+    # Public
+    # The timeout for reading in seconds. Defaults to 2
+    attr_accessor :read_timeout
+
+    # Public
+    # The timeout for writing in seconds. Defaults to 2
+    attr_accessor :write_timeout
 
     def initialize( host, port = 22133, options = {} )
       if port.is_a?(Hash)
@@ -32,11 +42,68 @@ module KJess
       @connect_timeout = options[:connect_timeout] || 2
       @read_timeout    = options[:read_timeout]    || 2
       @write_timeout   = options[:write_timeout]   || 2
-      @eol             = options[:eol]             || Protocol::CRLF
 
-      @read_buffer = ''
-      @socket      = nil
+      @socket         = nil
+      @read_buffer    = ''
+      @read_deadline  = nil
+      @write_deadline = nil
     end
+
+    # Internal: Starts the read timeout deadline for operations
+    #
+    # timeout - the timeout to set in seconds. This value is added to the
+    #           class-wide `read_timeout`
+    #
+    # Returns nothing
+    def with_read_timeout(timeout = nil, &block)
+      if @read_deadline
+        block.call
+      else
+        begin
+          @current_read_timeout = timeout ? timeout + @read_timeout : @read_timeout
+          @read_deadline = Time.now.to_f + @current_read_timeout
+          block.call
+        ensure
+          @current_read_timeout = @read_deadline = nil
+        end
+      end
+    end
+
+    # Internal: Gets the current read timeout
+    #
+    # Returns an Integer
+    def read_timeout_for_deadline
+      timeout = @read_deadline ? @read_deadline - Time.now.to_f : @read_timeout
+      if timeout <= 0
+        raise Timeout, "Could not read from #{host}:#{port} in #{@current_read_timeout} seconds"
+      end
+      timeout
+    end
+
+    # Internal: Starts the write timeout deadline for operations
+    #
+    # Returns nothing
+    def with_write_timeout(&block)
+      if @write_deadline
+        block.call
+      else
+        begin
+          @write_deadline = Time.now.to_f + @write_timeout
+          block.call
+        ensure
+          @write_deadline = nil
+        end
+      end
+    end
+
+    def write_timeout_for_deadline
+      timeout = @write_deadline ? @write_deadline - Time.now.to_f : @write_timeout
+      if timeout <= 0
+        raise Timeout, "Could not write to #{host}:#{port} in #{@write_timeout} seconds"
+      end
+      timeout
+    end
+
 
     # Internal: Return the raw socket that is connected to the Kestrel server
     #
@@ -46,7 +113,9 @@ module KJess
     # Returns a TCPSocket
     def socket
       return @socket if @socket and not @socket.closed?
-      return @socket = connect()
+      @socket = connect()
+      @read_buffer = ''
+      @socket
     end
 
     # Internal: Create the socket we use to talk to the Kestrel server
@@ -111,6 +180,7 @@ module KJess
     # Returns nothing
     def close
       @socket.close if @socket and not @socket.closed?
+      @read_buffer = ''
       @socket = nil
     end
 
@@ -129,8 +199,19 @@ module KJess
     #
     # Returns nothing
     def write( msg )
-      $stderr.write "--> #{msg}" if $DEBUG
-      socket.write( msg )
+      with_write_timeout do
+        $stderr.puts "--> #{msg}" if $DEBUG
+
+        begin
+          until msg.length == 0
+            written = socket.syswrite(msg)
+            msg = msg[written, msg.size]
+          end
+        rescue Errno::EWOULDBLOCK, Errno::EINTR, Errno::EAGAIN
+          IO.select(nil, [socket], nil, write_timeout_for_deadline)
+          retry
+        end
+      end
     end
 
     # Internal: read a single line from the socket
@@ -138,27 +219,23 @@ module KJess
     # eom - the End Of Mesasge delimiter (default: "\r\n")
     #
     # Returns a String
-    def readline( read_timeout = nil )
-      read_timeout ||= @read_timeout
-
-      deadline = Time.now.to_f + read_timeout
-
-      begin
-        while (idx = @read_buffer.index(@eol)) == nil
-          timeout = deadline - Time.now.to_f
-          if timeout <= 0
-            @read_buffer = result + @read_buffer
-            raise Timeout, "Could not read from #{host}:#{port}"
+    def readline( eom = Protocol::CRLF )
+      with_read_timeout do
+        while true
+          while (idx = @read_buffer.index(eom)) == nil
+            readpartial(4096, @read_buffer)
           end
 
-          @read_buffer << readpartial(4096, timeout)
+          line = @read_buffer.slice!(0, idx + eom.bytesize)
+          $stderr.puts "<-- #{line}" if $DEBUG
+          break unless line.strip.length == 0
         end
 
-        line = @read_buffer.slice!(0, idx + @eol.bytesize)
-        $stderr.write "<-- #{line}" if $DEBUG
-        retry if line.strip.length == 0
         return line
       end
+    rescue Timeout
+      close
+      raise
     rescue EOFError
       close
       return "EOF"
@@ -169,39 +246,24 @@ module KJess
     # args - this method takes the same arguments as IO#read
     #
     # Returns what IO#read returns
-    def read( nbytes, read_timeout = nil )
-      read_timeout ||= @read_timeout
-
-      deadline = Time.now.to_f + read_timeout
-
-      result = @read_buffer.slice!(0, nbytes)
-
-      while result.bytesize < nbytes
-        timeout = deadline - Time.now.to_f
-        if timeout <= 0
-          @read_buffer = result + @read_buffer
-          raise Timeout, "Could not read from #{host}:#{port}"
+    def read( nbytes )
+      with_read_timeout do
+        while @read_buffer.bytesize < nbytes
+          readpartial(nbytes - @read_buffer.bytesize, @read_buffer)
         end
 
-        result << readpartial(nbytes - result.bytesize, timeout)
-      end
+        result = @read_buffer.slice!(0, nbytes)
 
-      $stderr.puts "<-- #{result}" if $DEBUG
-      return result
+        $stderr.puts "<-- #{result}" if $DEBUG
+        return result
+      end
     end
 
-    def readpartial(maxlen, timeout = nil )
-      timeout ||= @read_timeout
-
-      begin
-        socket.read_nonblock(maxlen)
-      rescue Errno::EWOULDBLOCK, Errno::EAGAIN
-        if IO.select([socket], nil, nil, timeout)
-          retry
-        else
-          raise Timeout, "Could not read from #{host}:#{port} in #{timeout} seconds"
-        end
-      end
+    def readpartial(maxlen, outbuf = nil)
+      return socket.sysread(maxlen, outbuf)
+    rescue Errno::EWOULDBLOCK, Errno::EAGAIN
+      IO.select([socket], nil, nil, read_timeout_for_deadline)
+      retry
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-#$DEBUG = true 
+# $DEBUG = true
 describe KJess::Client do
   before do
-    @client = KJess::Client.new
+    @client = KJess::Client.new(:host => '127.0.0.1', :port => 22129)
   end
 
   after do
@@ -64,6 +64,12 @@ describe KJess::Client do
         break if s['curr_items'] == 1
       end
       @client.get( 'set_q_2' ).must_equal 'setspec2'
+    end
+
+    it 'a really long binary item' do
+      binary = (0..255).to_a.pack('c*') * 100
+      @client.set 'set_bin_q', binary
+      @client.get('set_bin_q').must_equal binary
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -262,4 +262,18 @@ describe KJess::Client do
       @client.ping.must_equal true
     end
   end
+
+  describe "connecting to a server on a port that isn't listening" do
+    it "throws an exception" do
+      c = KJess::Connection.new '127.0.0.1', 65521
+      lambda { c.socket }.must_raise KJess::Connection::Error
+    end
+  end
+
+  describe "connecting to a server that isn't responding" do
+    it "throws an exception" do
+      c = KJess::Connection.new '127.1.1.1', 65521, :timeout => 0.5
+      lambda { c.socket }.must_raise KJess::Connection::Timeout
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -282,4 +282,48 @@ describe KJess::Client do
       lambda { c.socket }.must_raise KJess::Connection::Timeout
     end
   end
+
+  describe "reading for longer than the timeout" do
+    it "throws an exception" do
+      t = Thread.new do
+        begin
+          server = TCPServer.new 65520
+          client = server.accept
+          Thread.stop
+        ensure
+          server.close rescue nil
+          client.close rescue nil
+        end
+      end
+
+      c = KJess::Connection.new '127.0.0.1', 65520, :timeout => 0.5
+
+      lambda { c.readline }.must_raise KJess::Connection::Timeout
+
+      t.run
+      t.join
+    end
+  end
+
+  describe "writing for longer than the timeout" do
+    it "throws an exception" do
+      t = Thread.new do
+        begin
+          server = TCPServer.new 65520
+          client = server.accept
+          Thread.stop
+        ensure
+          server.close rescue nil
+          client.close rescue nil
+        end
+      end
+
+      c = KJess::Connection.new '127.0.0.1', 65520, :timeout => 0.5
+
+      lambda { c.write('a' * 10000000) }.must_raise KJess::Connection::Timeout
+
+      t.run
+      t.join
+    end
+  end
 end

--- a/spec/kestrel_server.rb
+++ b/spec/kestrel_server.rb
@@ -47,7 +47,9 @@ import net.lag.kestrel.config._
 
 new KestrelConfig {
   listenAddress = "0.0.0.0"
-  memcacheListenPort = 22133
+  memcacheListenPort = 22129
+  textListenPort = 22298
+  thriftListenPort = 22299
 
   queuePath = "#{KJess::Spec::KestrelServer.queue_path}"
 
@@ -62,7 +64,7 @@ new KestrelConfig {
   default.maxMemorySize = 128.megabytes
   default.maxJournalSize = 1.gigabyte
 
-  admin.httpPort = 2223
+  admin.httpPort = 2230
 
   admin.statsNodes = new StatsConfig {
     reporters = new TimeSeriesCollectorConfig
@@ -80,7 +82,7 @@ _EOC
       end
 
       def get_response( path )
-        uri = URI.parse( "http://localhost:2223/#{path}" )
+        uri = URI.parse( "http://localhost:2230/#{path}" )
         resp = Net::HTTP.get_response( uri )
         JSON.parse( resp.body )
       end


### PR DESCRIPTION
## Overview

I believe very strongly that having short connect, read and write timeouts are vital in creating a robust distributed platform. Waiting for TCP socket timeouts of 120 seconds in the case of catastrophic hardware failure of one of the kestrel servers can lead to large delays in processing that otherwise could be resolved with short timeouts.
## The Solution

After reading [`redis/redis-rb`](https://github.com/redis/redis-rb) and many other libraries, I've decided the best way to provide configurable socket timeouts is by using non-blocking IO and using `IO.select()`.
## The Highlights

The `KJess::Connection` class provides `connect_timeout`, `read_timeout` and `write_timeout`. They can be updated with accessors at any time.

One problem with read timeouts in the ruby [`kestrel-client`](https://github.com/twitter/kestrel-client) is that they do not take into account the timeout provided to `get` operations, which means if the read timeout provided to the client is not greater than the largest get timeout, you can run into issues.

This solution adds the specified `get` timeout to the `read_timeout` to ensure that enough time is allowed when `KJess::Connection#with_read_timeout()` is called.

This pull request provides two methods:
- `KJess::Connection#with_read_timeout()`
- `KJess::Connection#with_write_timeout()`

which records a "deadline" (a time) in the connection for when the timeout will expire to make calculating the specific timeouts to pass to `IO.select()` easier.

`KJess::Connection#with_read_timeout()` is called in `KJess::Client#get()` to provide the additional timeout that should be added to the standard connection timeout.

`KJess::Connection#with_write_timeout()` is only called internally by `KJess::Connection#write()` to record the deadline timer.
